### PR TITLE
Timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ class CalendarListener
     {
         $start = $calendar->getStart();
         $end = $calendar->getEnd();
+        $timezone = $calendar->getTimezone();
         $filters = $calendar->getFilters();
 
         // You may want to make a custom query to fill the calendar
@@ -92,6 +93,32 @@ class CalendarListener
         $calendar->addEvent(new Event(
             'All day event',
             new \DateTime('Friday this week')
+        ));
+
+        // If you want to specify DateTime format for correct timezone handling
+        // see examples here https://fullcalendar.io/docs/timeZone
+        $calendar->addEvent(new Event(
+            'Event 2018-09-01T12:30:00Z',
+            new \DateTime('12:30'),
+            new \DateTime('13:30'),
+            [],
+            Event::DATE_FORMAT_ISO_8601_UTC // this is default
+        ));
+
+        $calendar->addEvent(new Event(
+            'Event 2018-09-01T12:30:00+XX:XX',
+            new \DateTime('12:30'),
+            new \DateTime('13:30'),
+            [],
+            Event::DATE_FORMAT_ISO_8601_WITH_OFFSET
+        ));
+
+        $calendar->addEvent(new Event(
+            'Event 2018-09-01T12:30:00',
+            new \DateTime('12:30'),
+            new \DateTime('13:30'),
+            [],
+            Event::DATE_FORMAT_ISO_8601_WITHOUT_OFFSET
         ));
     }
 }

--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -38,10 +38,11 @@ class CalendarController extends AbstractController
         $end = new \DateTime($request->get('end'));
         $filters = $request->get('filters', '{}');
         $filters = \is_array($filters) ? $filters : json_decode($filters, true);
+        $timezone = $request->get('timeZone');
 
         $event = $this->eventDispatcher->dispatch(
             CalendarEvents::SET_DATA,
-            new CalendarEvent($start, $end, $filters)
+            new CalendarEvent($start, $end, $filters, $timezone)
         );
         $content = $this->serializer->serialize($event->getEvents());
 

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -6,7 +6,14 @@ namespace CalendarBundle\Entity;
 
 class Event
 {
-    const DATE_FORMAT = 'Y-m-d\\TH:i:s.u\\Z';
+    // 2018-09-01T12:30:00+XX:XX
+    public const DATE_FORMAT_ISO_8601_WITH_OFFSET = 'Y-m-d\\TH:i:sP';
+    // 2018-09-01T12:30:00
+    public const DATE_FORMAT_ISO_8601_WITHOUT_OFFSET = 'Y-m-d\\TH:i:s';
+    // 2018-09-01T12:30:00Z
+    public const DATE_FORMAT_ISO_8601_UTC = 'Y-m-d\\TH:i:s\\Z';
+    // backward compatibility
+    public const DATE_FORMAT = self::DATE_FORMAT_ISO_8601_UTC;
 
     /**
      * @var string
@@ -34,18 +41,26 @@ class Event
     protected $options = [];
 
     /**
+     * @var string
+     */
+    protected $dateFormat;
+
+    /**
      * @param \DateTimeInterface $end
+     * @param string $dateFormat
      */
     public function __construct(
         string $title,
         \DateTimeInterface $start,
         \DateTimeInterface $end = null,
-        array $options = []
+        array $options = [],
+        string $dateFormat = self::DATE_FORMAT_ISO_8601_UTC
     ) {
         $this->setTitle($title);
         $this->setStart($start);
         $this->setEnd($end);
         $this->setOptions($options);
+        $this->setDateFormat($dateFormat);
     }
 
     /**
@@ -132,16 +147,32 @@ class Event
         return $removed;
     }
 
+    /**
+     * @return string
+     */
+    public function getDateFormat(): string
+    {
+        return $this->dateFormat;
+    }
+
+    /**
+     * @param string $dateFormat
+     */
+    public function setDateFormat(string $dateFormat): void
+    {
+        $this->dateFormat = $dateFormat;
+    }
+
     public function toArray(): array
     {
         $event = [
             'title' => $this->getTitle(),
-            'start' => $this->getStart()->format(self::DATE_FORMAT),
+            'start' => $this->getStart()->format($this->getDateFormat()),
             'allDay' => $this->isAllDay(),
         ];
 
         if (null !== $this->getEnd()) {
-            $event['end'] = $this->getEnd()->format(self::DATE_FORMAT);
+            $event['end'] = $this->getEnd()->format($this->getDateFormat());
         }
 
         return array_merge($event, $this->getOptions());

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -147,17 +147,11 @@ class Event
         return $removed;
     }
 
-    /**
-     * @return string
-     */
     public function getDateFormat(): string
     {
         return $this->dateFormat;
     }
 
-    /**
-     * @param string $dateFormat
-     */
     public function setDateFormat(string $dateFormat): void
     {
         $this->dateFormat = $dateFormat;

--- a/src/Event/CalendarEvent.php
+++ b/src/Event/CalendarEvent.php
@@ -29,14 +29,21 @@ class CalendarEvent extends BaseEvent
      */
     protected $events = [];
 
+    /**
+     * @var string|null
+     */
+    private $timezone;
+
     public function __construct(
         \DateTimeInterface $start,
         \DateTimeInterface $end,
-        array $filters
+        array $filters,
+        ?string $timezone = null
     ) {
         $this->start = $start;
         $this->end = $end;
         $this->filters = $filters;
+        $this->timezone = $timezone;
     }
 
     public function getStart(): \DateTimeInterface
@@ -52,6 +59,11 @@ class CalendarEvent extends BaseEvent
     public function getFilters(): array
     {
         return $this->filters;
+    }
+
+    public function getTimezone(): ?string
+    {
+        return $this->timezone;
     }
 
     /**

--- a/tests/Controller/CalendarControllerTest.php
+++ b/tests/Controller/CalendarControllerTest.php
@@ -43,6 +43,7 @@ class CalendarControllerTest extends TestCase
         $this->request->get('start')->willReturn('2016-03-01');
         $this->request->get('end')->willReturn('2016-03-19 15:11:00');
         $this->request->get('filters', '{}')->willReturn('{}');
+        $this->request->get('timeZone')->willReturn(null);
 
         $this->calendarEvent->getEvents()->willReturn([$this->event]);
 
@@ -83,6 +84,7 @@ class CalendarControllerTest extends TestCase
         $this->request->get('start')->willReturn('2016-03-01');
         $this->request->get('end')->willReturn('2016-03-19 15:11:00');
         $this->request->get('filters', '{}')->willReturn('{}');
+        $this->request->get('timeZone')->willReturn(null);
 
         $this->calendarEvent->getEvents()->willReturn([$this->event]);
 


### PR DESCRIPTION
Timezone param is sent when timezone is specified, but it was not passed to calendar event.
Datetimes returned from event entity were formatted as in UTC timezone, but actually they were just losing their offset.
That's all fixed with this pull request, following FullCalendar docs https://fullcalendar.io/docs/timeZone