### PR TITLE
Updated routing to remove deprecation message

### DIFF
--- a/src/Resources/config/routing.yaml
+++ b/src/Resources/config/routing.yaml
@@ -1,4 +1,4 @@
 fc_load_events:
     path: /fc-load-events
     defaults:
-        _controller: CalendarBundle\Controller\CalendarController:loadAction
+        _controller: CalendarBundle\Controller\CalendarController::loadAction


### PR DESCRIPTION
[2021-06-14T15:58:50.809880+02:00] deprecation.INFO: User Deprecated: Since symfony/http-kernel 5.1: Referencing controllers with a single colon is deprecated. Use "CalendarBundle\Controller\CalendarController::loadAction" instead. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Since symfony/http-kernel 5.1: Referencing controllers with a single colon is deprecated. Use \"CalendarBundle\\Controller\\CalendarController::loadAction\" instead.