### PR TITLE
chore: allow phpunit 10

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -11,7 +11,7 @@ jobs:
         php: ['8.2']
         stability: [ prefer-stable ]
         minimum-stability: [ stable ]
-        symfony-version: ['6.3.*']
+        symfony-version: ['6.4.*']
         include:
           - php: '8.0'
             symfony-version: 5.4.*
@@ -25,15 +25,12 @@ jobs:
           - php: '8.2'
             symfony-version: 6.3.*
             stability: prefer-stable
-          # change after phpspec/prophecy supports php 8.3
-          #- php: '8.3'
-            #symfony-version: 6.3.*
-            #stability: prefer-stable
-            #--ignore-platform-req=php+
-          - php: '8.2'
-            symfony-version: 7.0.x@dev
+          - php: '8.3'
+            symfony-version: 6.4.*
             stability: prefer-stable
-            minimum-stability: dev
+          - php: '8.3'
+            symfony-version: 7.0.*
+            stability: prefer-stable
 
     name: PHP ${{ matrix.php }} - ${{ matrix.symfony-version }} - ${{ matrix.stability }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .php_cs.cache
 .phpunit.result.cache
 composer.lock
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,9 @@
         "symfony/framework-bundle": "^5.4 || ^6.3 || ^7.0"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.17",
-        "phpunit/phpunit": "^9.6",
+        "phpspec/prophecy": "^1.8",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.6 || ^10.4",
         "symfony/dotenv": "^5.4 || ^6.3 || ^7.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.3 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.3 || ^7.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
          bootstrap="./vendor/autoload.php">
+
     <coverage includeUncoveredFiles="true">
         <include>
             <directory>.</directory>
@@ -17,17 +19,20 @@
             <xml outputDirectory="build/coverage-xml"/>
         </report>
     </coverage>
+
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0"/>
     </php>
+
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
     <logging/>
+
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>

--- a/tests/Controller/CalendarControllerTest.php
+++ b/tests/Controller/CalendarControllerTest.php
@@ -12,12 +12,15 @@ use CalendarBundle\Serializer\SerializerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CalendarControllerTest extends TestCase
 {
+    use ProphecyTrait;
+
     private ObjectProphecy|CalendarEvent $calendarEvent;
     private Event|ObjectProphecy $event;
     private ObjectProphecy|EventDispatcherInterface $eventDispatcher;


### PR DESCRIPTION
PhpUnit 10 needs a trait to use prophesize()
`PHPUnit\Framework\TestCase::prophesize() is deprecated and will be removed in PHPUnit 10. Please use the trait provided by phpspec/prophecy-phpunit.`

This needs to be merged to get PhpUnit 10 installed and working.
https://github.com/phpspec/prophecy-phpunit/pull/45