### PR TITLE
Feature/php8 perf

### DIFF
--- a/src/Event/CalendarEvent.php
+++ b/src/Event/CalendarEvent.php
@@ -41,9 +41,9 @@ class CalendarEvent
         return $this->filters;
     }
 
-    public function addEvent(Event $event): self
+    public function addEvent(Event $event, bool $checkUnique=false): self
     {
-        if (!\in_array($event, $this->events, true)) {
+        if (!$checkUnique || !\in_array($event, $this->events, true)) {
             $this->events[] = $event;
         }
 

--- a/tests/Event/CalendarEventTest.php
+++ b/tests/Event/CalendarEventTest.php
@@ -6,6 +6,7 @@ namespace CalendarBundle\Tests\Event;
 
 use CalendarBundle\Entity\Event;
 use CalendarBundle\Event\CalendarEvent;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CalendarEventTest extends TestCase
@@ -13,7 +14,10 @@ class CalendarEventTest extends TestCase
     private \DateTime $start;
     private \DateTime $end;
     private array $filters;
+    /** @var Event&MockObject $eventEntity */
     private $eventEntity;
+    /** @var Event&MockObject $eventEntity2 */
+    private $eventEntity2;
     private CalendarEvent $event;
 
     public function setUp(): void
@@ -23,6 +27,7 @@ class CalendarEventTest extends TestCase
         $this->filters = [];
 
         $this->eventEntity = $this->createMock(Event::class);
+        $this->eventEntity2 = $this->createMock(Event::class);
 
         $this->event = new CalendarEvent(
             $this->start,
@@ -40,7 +45,19 @@ class CalendarEventTest extends TestCase
 
     public function testItHandleEvents(): void
     {
+        $this->assertCount(0, $this->event->getEvents());
+
         $this->event->addEvent($this->eventEntity);
         $this->assertEquals([$this->eventEntity], $this->event->getEvents());
+        $this->assertCount(1, $this->event->getEvents());
+
+        $this->event->addEvent($this->eventEntity, true);
+        $this->assertCount(1, $this->event->getEvents());
+
+        $this->event->addEvent($this->eventEntity);
+        $this->assertCount(2, $this->event->getEvents());
+
+        $this->event->addEvent($this->eventEntity2, true);
+        $this->assertCount(3, $this->event->getEvents());
     }
 }


### PR DESCRIPTION
Superseeds https://github.com/tattali/CalendarBundle/pull/57
With a possible solution for https://github.com/tattali/CalendarBundle/issues/46

Add a additional paramter if the event should be unique.
https://github.com/tattali/CalendarBundle/compare/master...Chris53897:feature/php8-perf?expand=1#diff-e29df28b700bc5afb6adaf9697c4489ddb60b252021b353e5d078af1f9e73a9eR44

Tests:
https://github.com/tattali/CalendarBundle/compare/master...Chris53897:feature/php8-perf?expand=1#diff-176744ef8dbdd61a7010c8f3dcb08b6e4647e4dfb8d9276f764c1c6131c9c41cR46

This is a BC Break if the default Value is `false`.
But maybe this is new major anyways.

For `isset` or `array_key_exists` an unique-Field like `id` has to be mandatory.
But this is a BC Break as well.