### PR TITLE
docs: improve docs, use php 8 level features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@ CalendarBundle - FullCalendar.js integration
 [![Total Downloads](https://poser.pugx.org/tattali/calendar-bundle/downloads)](https://packagist.org/packages/tattali/calendar-bundle)
 [![Latest Stable Version](https://poser.pugx.org/tattali/calendar-bundle/v/stable)](https://packagist.org/packages/tattali/calendar-bundle)
 
-This bundle allow you to integrate [FullCalendar.js](http://fullcalendar.io/) library in your Symfony 3 to 6 project.
+This bundle allow you to integrate [FullCalendar.js](https://fullcalendar.io/) library in your Symfony 3 to 6 project.
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/10502887/56835704-47687080-6875-11e9-9102-0533d2bbbf18.png" alt="Calendar image">
 </p>
 
+The following table shows the compatibilities of different versions of the bundle :
 
+| Version                                                               | Symfony        | PHP          |
+|-----------------------------------------------------------------------|----------------|--------------|
+| [1.3 (master)](https://github.com/tattali/CalendarBundle/tree/master) | ^5.4 + ^6.2    | >=8.0        |
+| [1.0](https://github.com/tattali/CalendarBundle/tree/1.x)             | ^3.4 - ^6.2    | ^7.1 and 8.0 |
 
-* Symfony 3.4+ or Symfony 4.0+ or Symfony 5.0+ or Symfony 6.0+
-* PHP v7.1+
 * No storage dependencies (Compatible with: Doctrine, MongoDB, CouchDB...)
 
 Documentation
@@ -120,17 +123,8 @@ Include the html template were you want to display the calendar:
 Add styles and js. Click [here](https://fullcalendar.io/download) to see other css and js download methods, you can also found the [plugins list](https://fullcalendar.io/docs/plugin-index)
 
 ```twig
-{% block stylesheets %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.1.0/main.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.1.0/main.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.1.0/main.min.css">
-{% endblock %}
-
 {% block javascripts %}
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.1.0/main.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@4.1.0/main.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.1.0/main.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.1.0/main.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.5/index.global.min.js" integrity="sha256-dHUNnePy81fXq4D/wfu7cPsEIP7zl6MvLb84jtZf+UY=" crossorigin="anonymous"></script>
 {% endblock %}
 ```
 
@@ -157,17 +151,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 },
             },
         ],
-        header: {
-            left: 'prev,next today',
+        headerToolbar: {
+            start: 'prev,next today',
             center: 'title',
-            right: 'dayGridMonth,timeGridWeek,timeGridDay',
+            end: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        plugins: [ 'interaction', 'dayGrid', 'timeGrid' ], // https://fullcalendar.io/docs/plugin-index
         timeZone: 'UTC',
     });
     calendar.render();
 });
 ```
+
+You can use [Plugins](https://fullcalendar.io/docs/plugin-index) to reduce loadtime.
 
 ## Troubleshoot AJAX requests
 

--- a/src/Resources/doc/doctrine-crud.md
+++ b/src/Resources/doc/doctrine-crud.md
@@ -45,33 +45,24 @@ In this example we call the entity `Booking`
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use App\Repository\BookingRepository;
 
-/**
- * @ORM\Entity(repositoryClass="App\Repository\BookingRepository")
- */
+#[ORM\Entity(repositoryClass: BookingRepository::class)]
 class Booking
 {
-    /**
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     * @ORM\Id
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id; # nullable for EasyAdmin
 
-    /**
-     * @ORM\Column(type="datetime")
-     */
-    private $beginAt;
+    #[ORM\Column(type: 'datetime')]
+    private ?\DateTimeInterface $beginAt;
 
-    /**
-     * @ORM\Column(type="datetime", nullable=true)
-     */
-    private $endAt = null;
+    #[ORM\Column(type: 'datetime', nullable:true)]
+    private ?\DateTimeInterface $endAt = null;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
-    private $title;
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $title;
 
     public function getId(): ?int
     {
@@ -167,16 +158,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/booking")
- */
+#[Route(path: '/booking')]
 class BookingController extends AbstractController
 {
     // ...
 
-    /**
-     * @Route("/calendar", name="app_booking_calendar", methods={"GET"})
-     */
+    #[Route(path: '/calendar', name: "app_booking_calendar", methods: ['GET'])]
     public function calendar(): Response
     {
         return $this->render('booking/calendar.html.twig');
@@ -215,16 +202,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CalendarSubscriber implements EventSubscriberInterface
 {
-    private $bookingRepository;
-    private $router;
-
     public function __construct(
-        BookingRepository $bookingRepository,
-        UrlGeneratorInterface $router
-    ) {
-        $this->bookingRepository = $bookingRepository;
-        $this->router = $router;
-    }
+        private BookingRepository $bookingRepository,
+        private UrlGeneratorInterface $router
+    )
+    {}
 
     // ...
 }
@@ -259,16 +241,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CalendarSubscriber implements EventSubscriberInterface
 {
-    private $bookingRepository;
-    private $router;
-
     public function __construct(
-        BookingRepository $bookingRepository,
-        UrlGeneratorInterface $router
-    ) {
-        $this->bookingRepository = $bookingRepository;
-        $this->router = $router;
-    }
+        private BookingRepository $bookingRepository,
+        private UrlGeneratorInterface $router
+    )
+    {}
 
     public static function getSubscribedEvents()
     {
@@ -355,17 +332,8 @@ Full template:
     <div id="calendar-holder"></div>
 {% endblock %}
 
-{% block stylesheets %}
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.1.0/main.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.1.0/main.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.1.0/main.min.css">
-{% endblock %}
-
 {% block javascripts %}
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/core@4.1.0/main.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@4.1.0/main.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/daygrid@4.1.0/main.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timegrid@4.1.0/main.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.5/index.global.min.js" integrity="sha256-dHUNnePy81fXq4D/wfu7cPsEIP7zl6MvLb84jtZf+UY=" crossorigin="anonymous"></script>
 
     <script type="text/javascript">
         document.addEventListener('DOMContentLoaded', () => {
@@ -386,12 +354,11 @@ Full template:
                         },
                     },
                 ],
-                header: {
-                    left: 'prev,next today',
+                headerToolbar: {
+                    start: 'prev,next today',
                     center: 'title',
-                    right: 'dayGridMonth,timeGridWeek,timeGridDay',
+                    end: 'dayGridMonth,timeGridWeek,timeGridDay'
                 },
-                plugins: [ 'interaction', 'dayGrid', 'timeGrid' ], // https://fullcalendar.io/docs/plugin-index
                 timeZone: 'UTC',
             });
             calendar.render();
@@ -399,6 +366,8 @@ Full template:
     </script>
 {% endblock %}
 ```
+
+You can use [Plugins](https://fullcalendar.io/docs/plugin-index) to reduce loadtime.
 
 * Now visit: <http://localhost:8000/booking/calendar>
 

--- a/src/Resources/doc/multi-calendar.md
+++ b/src/Resources/doc/multi-calendar.md
@@ -30,16 +30,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CalendarSubscriber implements EventSubscriberInterface
 {
-    private $bookingRepository;
-    private $router;
-
     public function __construct(
-        BookingRepository $bookingRepository,
-        UrlGeneratorInterface $router
-    ) {
-        $this->bookingRepository = $bookingRepository;
-        $this->router = $router;
-    }
+        private BookingRepository $bookingRepository,
+        private UrlGeneratorInterface $router
+    )
+    {}
 
     public static function getSubscribedEvents()
     {


### PR DESCRIPTION
i adjusted doc to 
- use the new  php 8 level features
- make is easier to use fullcalendar for beginners with the fullBundle integration
- change `header` to => `headerToolbar` https://fullcalendar.io/docs/headerToolbar

As there are some BC changes i would suggest to make a new major version.
i have some more ideas, but i will see how many free time i have to work on this.
So maybe wait a bit for a new major release.