### PR TITLE
feat: allow symfony 7

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -10,7 +10,8 @@ jobs:
       matrix:
         php: ['8.2']
         stability: [ prefer-stable ]
-        symfony-version: ['6.2.*']
+        minimum-stability: [ stable ]
+        symfony-version: ['6.3.*']
         include:
           - php: '8.0'
             symfony-version: 5.4.*
@@ -19,15 +20,24 @@ jobs:
             symfony-version: 5.4.*
             stability: prefer-stable
           - php: '8.1'
-            symfony-version: 6.2.*
+            symfony-version: 6.3.*
             stability: prefer-stable
           - php: '8.2'
-            symfony-version: 6.2.*
+            symfony-version: 6.3.*
             stability: prefer-stable
+          # change after phpspec/prophecy supports php 8.3
+          #- php: '8.3'
+            #symfony-version: 6.3.*
+            #stability: prefer-stable
+            #--ignore-platform-req=php+
+          - php: '8.2'
+            symfony-version: 7.0.x@dev
+            stability: prefer-stable
+            minimum-stability: dev
 
     name: PHP ${{ matrix.php }} - ${{ matrix.symfony-version }} - ${{ matrix.stability }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -48,7 +58,8 @@ jobs:
         run: |
           composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
-          composer update --no-interaction --prefer-dist --optimize-autoloader
+          composer config minimum-stability ${{ matrix.minimum-stability }}
+          composer update --no-interaction --prefer-dist
           vendor/bin/simple-phpunit install
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
     "require": {
         "php": ">=8.0",
         "ext-json": "*",
-        "symfony/dependency-injection": "^5.4 || ^6.2",
-        "symfony/event-dispatcher": "^5.4 || ^6.2",
-        "symfony/framework-bundle": "^5.4 || ^6.2"
+        "symfony/dependency-injection": "^5.4 || ^6.3 || ^7.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.3 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.3 || ^7.0"
     },
     "require-dev": {
         "phpspec/prophecy": "^1.17",
         "phpunit/phpunit": "^9.6",
-        "symfony/dotenv": "^5.4 || ^6.2",
-        "symfony/phpunit-bridge": "^5.4 || ^6.2",
-        "symfony/yaml": "^5.4 || ^6.2"
+        "symfony/dotenv": "^5.4 || ^6.3 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.3 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.3 || ^7.0"
     },
     "suggest": {
         "symfony/orm-pack": "To support Doctrine ORM and Migration.",


### PR DESCRIPTION
- bump github action versions
- bump minimum version of symfony for 6.x to 6.3 (6.2 has no support anymore) https://symfony.com/releases#maintained-symfony-branches
- add tests for symfony 7

I did not make a real test. Just checked that the ci is green.

CI can be simplified after stable releases of symfony 7.