### PR TITLE
remove unmaintained Symfony

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The following table shows the compatibilities of different versions of the bundl
 | Version                                                               | Symfony            | PHP          |
 |-----------------------------------------------------------------------|--------------------|--------------|
 | [1.3 (master)](https://github.com/tattali/CalendarBundle/tree/master) | ^5.4 + ^6.3 + ^7.0 | >=8.0        |
-| [1.0](https://github.com/tattali/CalendarBundle/tree/1.x)             | ^3.4 - ^6.2        | ^7.1 and 8.0 |
 
 * No storage dependencies (Compatible with: Doctrine, MongoDB, CouchDB...)
 


### PR DESCRIPTION
The link wasn't working anyway, Symfony 3 is long gone.