### PR TITLE
feat: drop support for PHP < 8.1

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -13,17 +13,17 @@ jobs:
         minimum-stability: [ stable ]
         symfony-version: ['6.4.*']
         include:
-          - php: '8.0'
+          - php: '8.1'
             symfony-version: 5.4.*
             stability: prefer-lowest
           - php: '8.1'
             symfony-version: 5.4.*
             stability: prefer-stable
           - php: '8.1'
-            symfony-version: 6.3.*
+            symfony-version: 6.4.*
             stability: prefer-stable
           - php: '8.2'
-            symfony-version: 6.3.*
+            symfony-version: 6.4.*
             stability: prefer-stable
           - php: '8.3'
             symfony-version: 6.4.*

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "symfony/dependency-injection": "^5.4 || ^6.3 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.3 || ^7.0",
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpspec/prophecy": "^1.8",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.6.17 || ^10.5.11 || ^11.0.4",
+        "phpunit/phpunit": "^10.5.11 || ^11.0.4",
         "symfony/dotenv": "^5.4 || ^6.3 || ^7.0",
         "symfony/phpunit-bridge": "^7.0",
         "symfony/yaml": "^5.4 || ^6.3 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     "require-dev": {
         "phpspec/prophecy": "^1.8",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.6 || ^10.4",
+        "phpunit/phpunit": "^9.6.17 || ^10.5.11 || ^11.0.4",
         "symfony/dotenv": "^5.4 || ^6.3 || ^7.0",
-        "symfony/phpunit-bridge": "^5.4 || ^6.3 || ^7.0",
+        "symfony/phpunit-bridge": "^7.0",
         "symfony/yaml": "^5.4 || ^6.3 || ^7.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,37 +3,36 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
-         bootstrap="./vendor/autoload.php">
+         bootstrap="./vendor/autoload.php"
+>
+  <coverage>
+    <report>
+      <clover outputFile="build/coverage.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <xml outputDirectory="build/coverage-xml"/>
+    </report>
+  </coverage>
 
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory>.</directory>
-        </include>
-        <exclude>
-            <directory>tests</directory>
-            <directory>vendor</directory>
-        </exclude>
-        <report>
-            <clover outputFile="build/coverage.xml"/>
-            <html outputDirectory="build/coverage"/>
-            <xml outputDirectory="build/coverage-xml"/>
-        </report>
-    </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <ini name="memory_limit" value="-1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0"/>
+  </php>
 
-    <php>
-        <ini name="error_reporting" value="-1"/>
-        <ini name="memory_limit" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0"/>
-    </php>
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <logging/>
+  <source>
+    <include>
+      <directory>.</directory>
+    </include>
+    <exclude>
+      <directory>tests</directory>
+      <directory>vendor</directory>
+    </exclude>
+  </source>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>


### PR DESCRIPTION
chore: allow PHPUnit 11
only use "symfony/phpunit-bridge" 7
remove PHPUnit-Bridge (re-Integrate later)